### PR TITLE
kubernetes-intro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.17.2
+EXPOSE 8000
+WORKDIR /app
+RUN apk add --no-cache nginx \
+    && rm /etc/nginx/http.d/default.conf \
+    && chmod -R 777 /var/lib/nginx/ \
+    && chmod -R 777 /var/log/nginx/
+USER 1001
+COPY nginx.conf /etc/nginx/
+COPY index.html /app/
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,29 @@ RUN apk add --no-cache nginx \
     && rm /etc/nginx/http.d/default.conf \
     && chmod -R 777 /var/lib/nginx/ \
     && chmod -R 777 /var/log/nginx/
-USER 1001
-COPY nginx.conf /etc/nginx/
+RUN echo $' \n\
+pid       /tmp/nginx.pid; \n\
+error_log /dev/stdout; \n\
+\n\
+events { \n\
+} \n\
+http { \n\
+    server { \n\
+        listen       8000; \n\
+        server_name  localhost; \n\
+        access_log /dev/stdout; \n\
+        client_body_temp_path /tmp/client_body; \n\
+        fastcgi_temp_path /tmp/fastcgi_temp; \n\
+        proxy_temp_path /tmp/proxy_temp; \n\
+        scgi_temp_path /tmp/scgi_temp; \n\
+        uwsgi_temp_path /tmp/uwsgi_temp; \n\
+        location / { \n\
+          root /app; \n\
+          index  index.html index.htm; \n\
+        } \n\
+    } \n\
+}' > /etc/nginx/nginx.conf
+#COPY nginx.conf /etc/nginx/
 COPY index.html /app/
+USER 1001
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # SpectreKr_platform
 SpectreKr Platform repository
+
+DZ #1
+1. Создан Dockerfile запускающий nginx от непривелигированного пользователя, слушающий 8000 порт и использующий каталог /app как рабочую дирикторию
+2. Создан манифест web-pod.yaml для запуска пода основанного на контейнере созданом с помощью dockerfile
+3. Создан манифест frontend-pod.yaml запуска frontend'a Hipster Shop, с помощью командной строки kubectl run frontend --image spectrekr/otus:frontend --restart=Never --dry-run -o yaml > frontend-pod.yaml
+4. Сохдан манифест frontend-pod-healthy.yaml исправляющий ошибки и запускающий frontend pod

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: spectrekr/otus:frontend
+    name: frontend
+    env:
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: spectrekr/otus:frontend
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  initContainers:
+    - name: get-page
+      image: busybox:1.35
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts: 
+        - name: app
+          mountPath: /app
+  containers: 
+    - name: web
+      image: spectrekr/otus:nginx
+      volumeMounts: 
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}


### PR DESCRIPTION
Hint: Поды ETC, kube-apiserver, kube-controller, kube-scheduler запускаются системной службой кубелет, под core-dns управляется deployments и пересоздается под управлением replicaset

# Выполнено ДЗ №1

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Создан Dockerfile запускающий nginx от непривелигированного пользователя, слушающий 8000 порт и использующий каталог /app как рабочую дирикторию
 - Создан манифест web-pod.yaml для запуска пода основанного на контейнере созданом с помощью dockerfile
 - Создан манифест frontend-pod.yaml запуска frontend'a Hipster Shop, с помощью командной строки kubectl run frontend --image spectrekr/otus:frontend --restart=Never --dry-run -o yaml > frontend-pod.yaml
 - Сохдан манифест frontend-pod-healthy.yaml исправляющий ошибки и запускающий frontend pod

## Как запустить проект:
 - kubectl apply -f frontend-pod-healthy.yaml

## Как проверить работоспособность:
 - kubectl -n default get pods

## PR checklist:
 - [x] Выставлен label с темой домашнего задания