### PR TITLE
kubernetes-operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kubernetes-operators/build/__pycache__

--- a/README.md
+++ b/README.md
@@ -64,3 +64,72 @@ DZ #6
 11. Вынес paymentservice в отдельный деплой с использование kubecfg.
 12. Вынес emailservice в отдельный деплой с использованием qbec.
 13. Вынес adservice в отдельный деплой с использованием kustomize, настроил деплой в 2 окружения hipster-shop и hipster-shop-prod.
+
+DZ #7
+1. Создали CRD и CR для развертывания mysql
+2. Создали mysql-operator выполняющий резервное копирование и восстановление БД
+3. Создали манифесты деплоя для mysql-operator
+4. Провели тестирование:
+```bash
+kubectl get jobs
+backup-mysql-instance-job    1/1           5s         6m23s
+restore-mysql-instance-job   1/1           43s        3m7s
+```
+```bash
+kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
+mysql: [Warning] Using a password on the command line interface can be insecure.
++----+-------------+
+| id | name        |
++----+-------------+
+|  1 | some data   |
+|  2 | some data-2 |
+|  3 | some data   |
+|  4 | some data-2 |
++----+-------------+
+```
+5. Добавление в описание объекта поля status с описанием создания инстанса.
+В описание схемы обязательно добавить параметр:
+x-kubernetes-preserve-unknown-fields: true
+Далее дорабатываем код нашего оператора, чтоб заполнял наше поле, вводим переменную состояния exists_backup. По умолчанию она равна True что подразумевает существование бэкапа, далее на этапе создания PVC для бекапа, в случае успешного создания, переменная принимает значение False, что означает отсутствие бекапа:
+```python
+if exists_backup:
+        return {'Message': 'mysql-instance created with restore-job'}
+    else:
+        return {'message': 'mysql-instance created without restore-job'}
+```
+Данный код проверяет состояние переменной отвечающей за наличие резервной копией и выставляет статус.
+```bash
+Spec:
+  Database:     otus-database
+  Image:        arm64v8/mysql
+  Password:     otuspassword
+  usless_data:  useless info
+Status:
+  mysql_on_create:
+    Message:  mysql-instance created without restore-job
+Events:
+  Type    Reason   Age   From  Message
+```
+6. Реализовал смену пароля пользователя при обновлении инстанса.
+Для этого добавил ашблон job change-pass.yml.j2 который запускает под и производит смену пароля пользователя.
+Код в операторе который отслеживает обновление поля spec.password и запускает job. Перед запуском job оператор определяет текущий пароль и предыдущий и передает их в под.
+```python
+@kopf.on.update('otus.homework', 'v1', 'mysqls', field='spec.password')
+def change_password(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    last_pass = yaml.load(body['metadata']['annotations']['kopf.zalando.org/last-handled-configuration'], Loader=SafeLoader)['spec']['password']
+
+    change_pass_job = render_template('change-pass.yml.j2', {
+                                      'name': name,
+                                      'image': image,
+                                      'password': password,
+                                      'last_pass': last_pass}
+                                      )
+    api = kubernetes.client.BatchV1Api()
+    api.create_namespaced_job('default', change_pass_job)
+    wait_until_job_end(f"change-pass-{name}-job")
+    delete_success_jobs(f"change-pass-{name}-job")
+    return {'Message': 'mysql-instance password changed'}
+```

--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,186 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+from yaml.loader import SafeLoader
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.load(yaml_manifest, Loader=SafeLoader)
+    return json_manifest
+
+
+def delete_success_jobs(jobname): #mysql_instance_name):
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+#        jobname = job.metadata.name
+#        if (jobname == f"backup-{mysql_instance_name}-job"):
+        if (job.metadata.name == jobname):
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname,
+                                          'default',
+                                          propagation_policy='Background'
+                                          )
+
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and \
+            any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                if job.status.succeeded == 1:
+                    job_finished = True
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def mysql_on_create(body, spec, **kwargs):
+    exists_backup = True
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    try:
+        storage_size = body['spec']['storage_size']
+    except KeyError:
+        storage_size = "1G"
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2',
+                                        {
+                                         'name': name,
+                                         'storage_size': storage_size
+                                         }
+                                        )
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2',
+                                              {
+                                               'name': name,
+                                               'storage_size': storage_size
+                                               }
+                                              )
+    service = render_template('mysql-service.yml.j2', {'name': name})
+    deployment = render_template('mysql-deployment.yml.j2',
+                                 {
+                                  'name': name,
+                                  'image': image,
+                                  'password': password,
+                                  'database': database
+                                  }
+                                 )
+    restore_job = render_template('restore-job.yml.j2', {
+                                  'name': name,
+                                  'image': image,
+                                  'password': password,
+                                  'database': database}
+                                  )
+
+    # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)  # addopt
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    kopf.append_owner_reference(restore_job, owner=body)
+    # Таким образом при удалении CR удалятся все, связанные с ним pv,pvc,svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    try:
+        api.create_persistent_volume(persistent_volume)
+    except kubernetes.client.rest.ApiException:
+        pass
+    # Создаем mysql PVC:
+    try:
+        api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    except kubernetes.client.rest.ApiException:
+        pass
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+
+    # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    # Cоздаем PVC  и PV для бэкапов:
+    backup_pv = render_template('backup-pv.yml.j2', {
+                                                     'name': name,
+                                                     'storage_size': storage_size
+                                                     })
+    api = kubernetes.client.CoreV1Api()
+    try:
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        pass
+    backup_pvc = render_template('backup-pvc.yml.j2', {
+                                                       'name': name,
+                                                       'storage_size': storage_size
+                                                       })
+    api = kubernetes.client.CoreV1Api()
+    try:
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+        exists_backup = False
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    # Проверяем происходило восстановление или нет
+    if exists_backup:
+        return {'Message': 'mysql-instance created with restore-job'}
+    else:
+        return {'message': 'mysql-instance created without restore-job'}
+
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    delete_success_jobs(f"backup-{name}-job") #name)
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {
+                                 'name': name,
+                                 'image': image,
+                                 'password': password,
+                                 'database': database
+                                 })
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    delete_success_jobs(f"backup-{name}-job")
+    return {'message': "mysql and its children resources deleted"}
+
+
+@kopf.on.update('otus.homework', 'v1', 'mysqls', field='spec.password')
+def change_password(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    # database = body['spec']['database']
+    last_pass = yaml.load(body['metadata']['annotations']['kopf.zalando.org/last-handled-configuration'], Loader=SafeLoader)['spec']['password']
+    #print(password, last_pass)
+
+    change_pass_job = render_template('change-pass.yml.j2', {
+                                      'name': name,
+                                      'image': image,
+                                      'password': password,
+                                      'last_pass': last_pass}
+                                      )
+    api = kubernetes.client.BatchV1Api()
+    api.create_namespaced_job('default', change_pass_job)
+    wait_until_job_end(f"change-pass-{name}-job")
+    delete_success_jobs(f"change-pass-{name}-job")
+    return {'Message': 'mysql-instance password changed'}

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/change-pass.yml.j2
+++ b/kubernetes-operators/build/templates/change-pass.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: change-pass-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: change-pass-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: change-pass-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - mysql -h {{ name }} -p'{{ last_pass }}' -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '{{ password }}';ALTER USER 'root'@'%' IDENTIFIED BY '{{ password }}';flush privileges;"

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+#        args:
+#        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: restore-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }} < /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: arm64v8/mysql
+  database: otus-database
+  password: otuspassword1
+  usless_data: "useless info"

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  scope: Namespaced
+  group: otus.homework
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            spec:
+              type: object
+              properties:
+                database:
+                  type: string
+                image:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+                usless_data:
+                  type: string
+              required:
+              - database
+              - image
+              - password
+  names:
+    kind: MySQL
+    plural: mysqls
+    singular: mysql
+    shortNames:
+    - ms

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: spectrekr/mysql-operator:latest
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Создали CRD и CR для развертывания mysql
 - Создали mysql-operator выполняющий резервное копирование и восстановление БД
 - Создали манифесты деплоя для mysql-operator
 - Провели тестирование.
 - Добавление в описание объекта поля status с описанием создания инстанса.
 - Реализовал смену пароля пользователя при обновлении инстанса.

## Как запустить проект:
 - kopf run mysql-operator.py

## Как проверить работоспособность:
 - kubectl apply -f deploy/cr.yml 
 -
 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}") && \
kubectl exec -it $MYSQLPOD -- mysql -u root  -potuspassword -e "CREATE TABLE test ( id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key(id) );" otus-database && \
kubectl exec -it $MYSQLPOD -- mysql -potuspassword  -e "INSERT INTO test ( id, name ) VALUES (null, 'some data' );" otus-database && \
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) VALUES (null, 'some data-2' );" otus-database && \
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
 - kubectl delete mysqls.otus.homework mysql-instance
 - kubectl apply -f deploy/cr.yml
 - 
 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}") && \
 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database

## PR checklist:
 - [x] Выставлен label с темой домашнего задания